### PR TITLE
feat(android): add title style support

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -38,6 +38,7 @@ A cross platform plugin for displaying local notifications.
    - [Handling notifications whilst the app is in the foreground](#handling-notifications-whilst-the-app-is-in-the-foreground)
 - **[❓ Usage](#-usage)**
    - [Notification Actions](#notification-actions)
+   - [[Android] Title text styling (API 24+)](#android-title-text-styling-api-24)
    - [Example app](#example-app)
    - [API reference](#api-reference)
 - **[Initialisation](#initialisation)**
@@ -629,6 +630,29 @@ Future<void> _showNotificationWithActions() async {
 ```
 
 Each notification will have a internal ID & an public action title.
+
+### [Android] Title text styling (API 24+)
+
+Style only the notification title on Android 7.0+ using a decorated custom
+layout. Older Android versions will silently fall back to the default system
+template.
+
+```dart
+final androidDetails = AndroidNotificationDetails(
+  'reminders',
+  'Reminders',
+  titleStyle: const AndroidNotificationTitleStyle(
+    color: 0xFF58CC02,
+    sizeSp: 16,
+    bold: true,
+    italic: false,
+  ),
+);
+```
+
+> [!NOTE]
+> This only affects the title text. Ensure sufficient contrast for
+> accessibility.
 
 ### Example app
 

--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
     }
 }
 
@@ -20,6 +21,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.dexterous.flutterlocalnotifications'
@@ -46,6 +48,7 @@ dependencies {
     implementation "androidx.core:core:1.3.0"
     implementation "androidx.media:media:1.1.0"
     implementation "com.google.code.gson:gson:2.12.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.23"
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -35,6 +35,7 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
 import android.util.Log;
+import android.widget.RemoteViews;
 
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
@@ -74,6 +75,7 @@ import com.dexterous.flutterlocalnotifications.models.styles.StyleInformation;
 import com.dexterous.flutterlocalnotifications.utils.BooleanUtils;
 import com.dexterous.flutterlocalnotifications.utils.LongUtils;
 import com.dexterous.flutterlocalnotifications.utils.StringUtils;
+import com.dexterous.flutterlocalnotifications.TitleStyler;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -443,6 +445,13 @@ public class FlutterLocalNotificationsPlugin
     setProgress(notificationDetails, builder);
     setCategory(notificationDetails, builder);
     setTimeoutAfter(notificationDetails, builder);
+    RemoteViews customView =
+        TitleStyler.build(context, notificationDetails.title, notificationDetails.titleStyle);
+    if (customView != null) {
+      builder.setCustomContentView(customView);
+      builder.setCustomBigContentView(customView);
+      builder.setStyle(new NotificationCompat.DecoratedCustomViewStyle());
+    }
     Notification notification = builder.build();
     if (notificationDetails.additionalFlags != null
         && notificationDetails.additionalFlags.length > 0) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -15,6 +15,7 @@ import com.dexterous.flutterlocalnotifications.models.styles.MessagingStyleInfor
 import com.dexterous.flutterlocalnotifications.models.styles.StyleInformation;
 import com.dexterous.flutterlocalnotifications.utils.LongUtils;
 import com.google.gson.annotations.SerializedName;
+import com.dexterous.flutterlocalnotifications.models.TitleStyle;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -128,6 +129,7 @@ public class NotificationDetails implements Serializable {
   private static final String COLORIZED = "colorized";
   private static final String NUMBER = "number";
   private static final String AUDIO_ATTRIBUTES_USAGE = "audioAttributesUsage";
+  private static final String TITLE_STYLE = "titleStyle";
 
   public Integer id;
   public String title;
@@ -198,6 +200,7 @@ public class NotificationDetails implements Serializable {
   public Boolean colorized;
   public Integer number;
   public Integer audioAttributesUsage;
+  public TitleStyle titleStyle;
 
   // Note: this is set on the Android to save details about the icon that should be used when
   // re-hydrating scheduled notifications when a device has been restarted.

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/TitleStyle.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/TitleStyle.java
@@ -1,0 +1,20 @@
+package com.dexterous.flutterlocalnotifications.models;
+
+import androidx.annotation.Keep;
+import com.google.gson.annotations.SerializedName;
+import java.io.Serializable;
+
+@Keep
+public class TitleStyle implements Serializable {
+  @SerializedName("color")
+  public Integer color;
+
+  @SerializedName("sizeSp")
+  public Double sizeSp;
+
+  @SerializedName("bold")
+  public Boolean bold;
+
+  @SerializedName("italic")
+  public Boolean italic;
+}

--- a/flutter_local_notifications/android/src/main/kotlin/com/dexterous/flutterlocalnotifications/TitleStyler.kt
+++ b/flutter_local_notifications/android/src/main/kotlin/com/dexterous/flutterlocalnotifications/TitleStyler.kt
@@ -1,0 +1,55 @@
+package com.dexterous.flutterlocalnotifications
+
+import android.content.Context
+import android.graphics.Typeface
+import android.os.Build
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.StyleSpan
+import android.util.Log
+import android.util.TypedValue
+import android.widget.RemoteViews
+import com.dexterous.flutterlocalnotifications.models.TitleStyle
+
+internal object TitleStyler {
+  private const val TAG = "TitleStyler"
+  private const val MAX_SIZE_SP = 26f
+
+  fun build(
+    context: Context,
+    title: CharSequence?,
+    style: TitleStyle?
+  ): RemoteViews? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+      return null
+    }
+    if (title.isNullOrEmpty() || style == null) {
+      return null
+    }
+    val remoteViews = RemoteViews(context.packageName, R.layout.fln_notif_title_only)
+    val viewId = R.id.fln_title
+    remoteViews.setTextViewText(viewId, title)
+
+    style.color?.let { remoteViews.setTextColor(viewId, it) }
+
+    style.sizeSp?.let {
+      if (it > 0) {
+        val size = it.toFloat().coerceAtMost(MAX_SIZE_SP)
+        remoteViews.setTextViewTextSize(viewId, TypedValue.COMPLEX_UNIT_SP, size)
+      } else {
+        Log.d(TAG, "Ignoring non-positive sizeSp: $it")
+      }
+    }
+
+    val bold = style.bold == true
+    val italic = style.italic == true
+    if (bold || italic) {
+      val flags = (if (bold) Typeface.BOLD else 0) or (if (italic) Typeface.ITALIC else 0)
+      val spannable = SpannableString(title)
+      spannable.setSpan(StyleSpan(flags), 0, spannable.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      remoteViews.setTextViewText(viewId, spannable)
+    }
+
+    return remoteViews
+  }
+}

--- a/flutter_local_notifications/android/src/main/res/layout/fln_notif_title_only.xml
+++ b/flutter_local_notifications/android/src/main/res/layout/fln_notif_title_only.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/fln_title"
+        style="@style/TextAppearance.Compat.Notification.Title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        android:ellipsize="end" />
+</LinearLayout>

--- a/flutter_local_notifications/android/src/test/java/com/dexterous/flutterlocalnotifications/TitleStylerTest.kt
+++ b/flutter_local_notifications/android/src/test/java/com/dexterous/flutterlocalnotifications/TitleStylerTest.kt
@@ -1,0 +1,67 @@
+package com.dexterous.flutterlocalnotifications
+
+import android.content.Context
+import android.graphics.Color
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import com.dexterous.flutterlocalnotifications.models.NotificationDetails
+import com.dexterous.flutterlocalnotifications.models.TitleStyle
+import com.dexterous.flutterlocalnotifications.models.styles.DefaultStyleInformation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class TitleStylerTest {
+  @Test
+  @Config(sdk = [24])
+  fun appliesCustomTitleStyle() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val details = NotificationDetails()
+    details.id = 1
+    details.title = "Title"
+    details.body = "Body"
+    details.channelId = "id"
+    details.channelName = "name"
+    details.styleInformation = DefaultStyleInformation(false, false)
+    val style = TitleStyle()
+    style.color = Color.RED
+    style.sizeSp = 16.0
+    style.bold = true
+    details.titleStyle = style
+
+    val notification =
+      FlutterLocalNotificationsPlugin.createNotification(context, details)
+    assertNotNull(notification.contentView)
+    assertEquals(R.layout.fln_notif_title_only, notification.contentView.layoutId)
+    val view = notification.contentView.apply(context, null)
+    val titleView = view.findViewById<TextView>(R.id.fln_title)
+    assertEquals(Color.RED, titleView.currentTextColor)
+    assertEquals(16f, titleView.textSize / context.resources.displayMetrics.scaledDensity, 0.1f)
+    assertEquals(true, titleView.typeface.isBold)
+  }
+
+  @Test
+  @Config(sdk = [23])
+  fun ignoresOnPre24() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val details = NotificationDetails()
+    details.id = 1
+    details.title = "Title"
+    details.body = "Body"
+    details.channelId = "id"
+    details.channelName = "name"
+    details.styleInformation = DefaultStyleInformation(false, false)
+    val style = TitleStyle()
+    style.color = Color.RED
+    details.titleStyle = style
+
+    val notification =
+      FlutterLocalNotificationsPlugin.createNotification(context, details)
+    assertNull(notification.contentView)
+  }
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -60,6 +60,15 @@ extension AndroidNotificationChannelMapper on AndroidNotificationChannel {
       }..addAll(_convertNotificationSoundToMap(sound));
 }
 
+extension AndroidNotificationTitleStyleMapper on AndroidNotificationTitleStyle {
+  Map<String, Object?> toMap() => <String, Object?>{
+        'color': color,
+        'sizeSp': sizeSp,
+        'bold': bold,
+        'italic': italic,
+      };
+}
+
 Map<String, Object> _convertNotificationSoundToMap(
     AndroidNotificationSound? sound) {
   if (sound is RawResourceAndroidNotificationSound) {
@@ -224,6 +233,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
         'colorized': colorized,
         'number': number,
         'audioAttributesUsage': audioAttributesUsage.value,
+        'titleStyle': titleStyle?.toMap(),
       }
         ..addAll(_convertActionsToMap(actions))
         ..addAll(_convertStyleInformationToMap())

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -104,6 +104,32 @@ class AndroidNotificationAction {
   final bool invisible;
 }
 
+/// Android-only options to style the *title* text using a custom layout.
+///
+/// Effective on Android API 24+; ignored below that.
+class AndroidNotificationTitleStyle {
+  /// 32-bit ARGB color (e.g., 0xFF58CC02). Null => platform default.
+  final int? color;
+
+  /// Font size in SP (logical scaled pixels). Must be > 0.
+  final double? sizeSp;
+
+  /// Whether to render title in bold. Defaults to null (platform default).
+  final bool? bold;
+
+  /// Whether to render title in italic. Defaults to null (platform default).
+  final bool? italic;
+
+  /// Constructs an instance of [AndroidNotificationTitleStyle].
+  const AndroidNotificationTitleStyle({
+    this.color,
+    this.sizeSp,
+    this.bold,
+    this.italic,
+  })  : assert(sizeSp == null || sizeSp > 0),
+        assert(color == null || (color >= 0 && color <= 0xFFFFFFFF));
+}
+
 /// Contains notification details specific to Android.
 class AndroidNotificationDetails {
   /// Constructs an instance of [AndroidNotificationDetails].
@@ -156,6 +182,7 @@ class AndroidNotificationDetails {
     this.colorized = false,
     this.number,
     this.audioAttributesUsage = AudioAttributesUsage.notification,
+    this.titleStyle,
   });
 
   /// The icon that should be used when displaying the notification.
@@ -426,4 +453,8 @@ class AndroidNotificationDetails {
   /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int)).
   /// https://developer.android.com/reference/android/media/AudioAttributes
   final AudioAttributesUsage audioAttributesUsage;
+
+  /// If set, uses a `DecoratedCustomViewStyle` with a custom `RemoteViews`
+  /// to render the title with the given style (API 24+ only).
+  final AndroidNotificationTitleStyle? titleStyle;
 }

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -42,6 +42,37 @@ void main() {
       });
     });
 
+    test('show with Android title style', () async {
+      const AndroidNotificationDetails androidNotificationDetails =
+          AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        titleStyle: AndroidNotificationTitleStyle(
+          color: 0xFF58CC02,
+          sizeSp: 16,
+          bold: true,
+          italic: true,
+        ),
+      );
+
+      await flutterLocalNotificationsPlugin.show(
+        1,
+        'notification title',
+        'notification body',
+        const NotificationDetails(android: androidNotificationDetails),
+      );
+
+      final Map<String, Object?> platformSpecifics =
+          (log.last.arguments as Map<String, Object?>)['platformSpecifics']
+              as Map<String, Object?>;
+      expect(platformSpecifics['titleStyle'], <String, Object?>{
+        'color': 0xFF58CC02,
+        'sizeSp': 16,
+        'bold': true,
+        'italic': true,
+      });
+    });
+
     tearDown(() {
       log.clear();
     });


### PR DESCRIPTION
## Summary
- add `AndroidNotificationTitleStyle` for title color, size, and style
- style notification titles on Android with decorated custom views
- document Android title text styling API

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5894438883339c6b5a511d8d0b85

## Summary by Sourcery

Add title text styling support for Android notifications by introducing AndroidNotificationTitleStyle with configurable color, size, bold, and italic options, implementing native TitleStyler with custom RemoteViews on API 24+, and updating mappings, tests, and documentation.

New Features:
- Introduce AndroidNotificationTitleStyle to configure notification title color, size, bold, and italic properties in Dart
- Implement native TitleStyler to render styled notification titles using DecoratedCustomViewStyle on Android API 24+
- Expose TitleStyle in the Android native models and map it through the method channel

Enhancements:
- Add Kotlin support and dependencies to the Android build configuration
- Include titleStyle in AndroidNotificationDetails mapping for MethodChannel serialization

Documentation:
- Document the Android title text styling API in the README

Tests:
- Add Dart unit test to verify titleStyle serialization in NotificationDetails
- Add Robolectric tests to verify TitleStyler applies styles on API 24+ and falls back on earlier versions